### PR TITLE
코멘트 실패시 타임아웃처리를 추가하였습니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "moment": "^2.22.2",
     "register-service-worker": "^1.0.0",
+    "uuid": "^3.3.2",
     "vue": "^2.5.16",
     "vue-router": "^3.0.1",
     "vue-tabs-component": "^1.4.0",

--- a/src/components/Test/TournaComment.vue
+++ b/src/components/Test/TournaComment.vue
@@ -29,7 +29,6 @@
     methods:{
       addComment(postId){
         let payload = {postId,commentBody:this.userComment,userId:123}
-        //this.$emit('putcomment',{postId,commentBody:this.userComment,userId:123})
         this.$emit('putcomment',payload)
       }
     }

--- a/src/components/Test/TournaComment.vue
+++ b/src/components/Test/TournaComment.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="l5">
     <div v-for="(elComment, idx) in comments" :key="idx" class="comment">
+      <span v-if="elComment.failed" class="failbadge">failed - server does not respond</span>
       <p><a :href="'mailto:' + elComment.email">{{elComment.name}}</a> - {{elComment.body}}</p>
-      <span v-if="elComment.failed" class="failbadge">failed!</span>
     </div>
     <div class="commentEditor">
       <textarea v-model="userComment" placeholder="write your own reply here"></textarea>
@@ -67,7 +67,7 @@
 
 <style lang="scss" scoped>
 .failbadge{
-  padding:2px;
+  padding:3px;
   color:white;
   background-color:palevioletred;
   font-size:0.5rem;

--- a/src/components/Test/TournaComment.vue
+++ b/src/components/Test/TournaComment.vue
@@ -2,6 +2,7 @@
   <div class="l5">
     <div v-for="(elComment, idx) in comments" :key="idx" class="comment">
       <p><a :href="'mailto:' + elComment.email">{{elComment.name}}</a> - {{elComment.body}}</p>
+      <span v-if="elComment.failed" class="failbadge">failed!</span>
     </div>
     <div class="commentEditor">
       <textarea v-model="userComment" placeholder="write your own reply here"></textarea>
@@ -12,6 +13,7 @@
 
 <script>
   import {mapActions} from 'vuex'
+  import uuidv4 from 'uuid/v4'
   export default{
     name:'TournaComments',
     data(){
@@ -25,17 +27,52 @@
         type:Number,
         default:0
       }
-    },    
+    },
+    computed:{
+    },
+    watch:{
+      comments:{
+        handler(){
+        },
+        deep:true
+      }
+    },
     methods:{
       addComment(postId){
-        let payload = {postId,commentBody:this.userComment,userId:123}
+        const tempId = uuidv4()
+        let payload = { postId,
+                        body:this.userComment,
+                        name:'abcdef',
+                        tempId,
+                        email:'test@1234.com' }
+        this.userComment = ''
         this.$emit('putcomment',payload)
+        const timeoutMax = 2000 //댓글 전송 실패시 타임아웃 = 2.0초
+        const _this = this
+        setTimeout(function(){
+          _this.comments.map(el=>{
+            if(el.tempId){
+              if(el.tempId === tempId){
+                el.failed = true
+              }
+            }
+            return el
+          })
+          _this.$forceUpdate()
+        },timeoutMax)
       }
     }
   }
 </script>
 
 <style lang="scss" scoped>
+.failbadge{
+  padding:2px;
+  color:white;
+  background-color:palevioletred;
+  font-size:0.5rem;
+  border-radius:3px;
+}
 .comment{
   text-align:left;
   border-bottom:solid 1px lightgray;

--- a/src/components/Test/TournaComment.vue
+++ b/src/components/Test/TournaComment.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="l5">
+    <div v-for="(elComment, idx) in comments" :key="idx" class="comment">
+      <p><a :href="'mailto:' + elComment.email">{{elComment.name}}</a> - {{elComment.body}}</p>
+    </div>
+    <div class="commentEditor">
+      <textarea v-model="userComment" placeholder="write your own reply here"></textarea>
+      <button @click="addComment(id)">Add Reply</button>
+    </div>
+  </div>
+</template>
+
+<script>
+  import {mapActions} from 'vuex'
+  export default{
+    name:'TournaComments',
+    data(){
+      return {
+        userComment: ''
+      }
+    },
+    props:{
+      comments:Array,
+      id:{
+        type:Number,
+        default:0
+      }
+    },    
+    methods:{
+      addComment(postId){
+        let payload = {postId,commentBody:this.userComment,userId:123}
+        //this.$emit('putcomment',{postId,commentBody:this.userComment,userId:123})
+        this.$emit('putcomment',payload)
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+.comment{
+  text-align:left;
+  border-bottom:solid 1px lightgray;
+}
+.commentEditor{
+  display:flex;
+  textarea{
+    flex-grow:1;
+    resize:vertical;
+    max-height:200px;
+  }
+  button{
+    background-color:gray;
+    border:none;
+    width:20%;
+    &:hover{
+      background-color:lightgray;
+    }
+  }
+}
+</style>

--- a/src/components/Test/TournaRow.vue
+++ b/src/components/Test/TournaRow.vue
@@ -2,7 +2,7 @@
   <div class="l4">
     <p>TournaRow: <span>{{ id }}</span> / <span>{{ userId }}</span></p>
     <p>{{ title }}</p>
-    <TournaComment :id="id" :comments="comments"></TournaComment>
+    <TournaComment :id="id" :comments="comments" @putcomment="putcomment"></TournaComment>
   </div>
 </template>
 
@@ -37,6 +37,9 @@ export default {
   // 컴포넌트 메서드 그룹
   watch: {},
   methods: {
+    putcomment(payload){
+      this.$emit('putcomment',payload)
+    }
   },
   // 컴포넌트 라이프사이클 메서드 그룹
   beforeCreate () {},

--- a/src/components/Test/TournaRow.vue
+++ b/src/components/Test/TournaRow.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="l4">
-    TournaRow: <span>{{ id }}</span> / <span>{{ userId }}</span></p>
+    <p>TournaRow: <span>{{ id }}</span> / <span>{{ userId }}</span></p>
     <p>{{ title }}</p>
+    <TournaComment :id="id" :comments="comments"></TournaComment>
   </div>
 </template>
 
 <script>
+import TournaComment from './TournaComment.vue'
+
 export default {
   name: 'TournaRow',
 
@@ -21,17 +24,20 @@ export default {
     userId: {
       type: Number,
       default: ''
-    }
+    },
+    comments:Array
   },
   // data() {},
   computed: {
   },
   // 컴포넌트가 다른 컴포넌트를 사용할 경우
   components: {
+    TournaComment
   },
   // 컴포넌트 메서드 그룹
   watch: {},
-  methods: {},
+  methods: {
+  },
   // 컴포넌트 라이프사이클 메서드 그룹
   beforeCreate () {},
   mounted () {

--- a/src/components/Test/TournaWholeList.vue
+++ b/src/components/Test/TournaWholeList.vue
@@ -52,13 +52,12 @@ export default {
   watch: {},
   methods: {
     putcomment(payload){
-      console.log(this.$store)
       this.$store.dispatch('test/putComment',payload)
     }
   },
   // 컴포넌트 라이프사이클 메서드 그룹
   beforeMount(){
-    console.log('store', this.$store)
+    console.log('loading up store', this.$store)
   },
   beforeCreate () {},
   mounted () {}

--- a/src/components/Test/TournaWholeList.vue
+++ b/src/components/Test/TournaWholeList.vue
@@ -2,7 +2,7 @@
   <div class="l2">
     TournaWholeList
     <div class="item" v-for="post in filteredPosts" :key="post.id">
-      <TournaRow v-bind="post" />
+      <TournaRow v-bind="post" @putcomment="putcomment"/>
     </div>
   </div>
 </template>
@@ -51,6 +51,10 @@ export default {
   // 컴포넌트 메서드 그룹
   watch: {},
   methods: {
+    putcomment(payload){
+      console.log(this.$store)
+      this.$store.dispatch('test/putComment',payload)
+    }
   },
   // 컴포넌트 라이프사이클 메서드 그룹
   beforeMount(){

--- a/src/components/Test/TournaWholeList.vue
+++ b/src/components/Test/TournaWholeList.vue
@@ -17,18 +17,27 @@ export default {
   computed: {
     ...mapState({
       posts: state => state.test.posts,
+      comments: state => state.test.comments,
       searchOptions: state => state.test.searchOptions
     }),
     filteredPosts () {
       console.log('filtered', this.posts, this.searchOptions.userId)
+      let posts
       if(this.searchOptions.userId == ''){
         console.log('here')
-        return this.posts
+        posts = this.posts
       } else {
-        return this.posts.filter(el => {
+        posts = this.posts.filter(el => {
           return (parseInt(this.searchOptions.userId) === el.userId)
         })
       }
+      //linking comments to computed post lists
+      return posts.map(el=>{
+        return {...el,
+                comments: this.comments.filter(
+                  elComment=>elComment.postId === el.id
+                )}
+      })
     }
     // posts () {
     //   console.log('dd',this.$store.state);
@@ -41,8 +50,12 @@ export default {
   },
   // 컴포넌트 메서드 그룹
   watch: {},
-  methods: {},
+  methods: {
+  },
   // 컴포넌트 라이프사이클 메서드 그룹
+  beforeMount(){
+    console.log('store', this.$store)
+  },
   beforeCreate () {},
   mounted () {}
 }

--- a/src/services/test.service.js
+++ b/src/services/test.service.js
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import { ResponseWrapper, ErrorWrapper } from './util'
 
-
 class TestService {
   getPosts () {
     return new Promise((resolve, reject) => {
@@ -44,9 +43,9 @@ class TestService {
     })
   }
 
-  putComment ({userId, postId, commentBody}) {
+  putComment ({name, postId, body, email}) {
     return new Promise((resolve, reject) => {
-      console.log(`user ${userId} puts comment on post id ${postId}\n: ${commentBody}`)
+      console.log(`user ${name}(${email}) puts comment on post id ${postId}\n: ${body}`)
       axios.post('https://jsonplaceholder.typicode.com/posts/')
         .then(res => {
           console.log('service putComment success!')

--- a/src/services/test.service.js
+++ b/src/services/test.service.js
@@ -12,6 +12,48 @@ class TestService {
         }).catch(error => reject(new ErrorWrapper(error)))
     })
   }
+
+  /*
+  * API calls for getting comments
+  * from views/TestPage.vue
+  * ->components/Test/TournaWholeList.vue
+  * ->components/Test/TournaRow.vue
+  * ->components/Test/TournaComment.vue
+  */
+
+  /*
+  //Comment data example
+  [
+    {
+      "postId": 1,
+      "id": 1,
+      "name": "id labore ex et quam laborum",
+      "email": "Eliseo@gardner.biz",
+      "body": "laudantium enim quasi est quidem magnam voluptate ipsam eos\ntempora quo necessitatibus\ndolor quam autem quasi\nreiciendis et nam sapiente accusantium"
+    }, ...
+  ]
+  */
+
+ getComments() {
+  return new Promise((resolve, reject) => {
+    axios.get('https://jsonplaceholder.typicode.com/comments')
+      .then(res => {
+        console.log('service getComments', res.data)
+        return resolve(new ResponseWrapper(res, res.data))
+      }).catch(err => reject(new ErrorWrapper(err)))
+    })
+  }
+
+  putCommment({userId,postId,commentBody}){
+    return new Promise((resolve,reject)=>{
+      console.log(`user ${userId} puts comment on post id ${postId}\n: ${commentBody}`)
+      axios.put('https://jsonplaceholder.typicode.com/posts/')
+        .then(res =>{
+          console.log('service putComment success!')
+          return resolve(new ResponseWrapper(res,res.data))
+        }).catch(err=> reject(new ErrorWrapper(err)))
+    })
+  }
 }
 
 export default new TestService()

--- a/src/services/test.service.js
+++ b/src/services/test.service.js
@@ -34,24 +34,24 @@ class TestService {
   ]
   */
 
- getComments() {
-  return new Promise((resolve, reject) => {
-    axios.get('https://jsonplaceholder.typicode.com/comments')
-      .then(res => {
-        console.log('service getComments', res.data)
-        return resolve(new ResponseWrapper(res, res.data))
-      }).catch(err => reject(new ErrorWrapper(err)))
+  getComments () {
+    return new Promise((resolve, reject) => {
+      axios.get('https://jsonplaceholder.typicode.com/comments')
+        .then(res => {
+          console.log('service getComments', res.data)
+          return resolve(new ResponseWrapper(res, res.data))
+        }).catch(err => reject(new ErrorWrapper(err)))
     })
   }
 
-  putCommment({userId,postId,commentBody}){
-    return new Promise((resolve,reject)=>{
+  putComment ({userId, postId, commentBody}) {
+    return new Promise((resolve, reject) => {
       console.log(`user ${userId} puts comment on post id ${postId}\n: ${commentBody}`)
-      axios.put('https://jsonplaceholder.typicode.com/posts/')
-        .then(res =>{
+      axios.post('https://jsonplaceholder.typicode.com/posts/')
+        .then(res => {
           console.log('service putComment success!')
-          return resolve(new ResponseWrapper(res,res.data))
-        }).catch(err=> reject(new ErrorWrapper(err)))
+          return resolve(new ResponseWrapper(res, res.data))
+        }).catch(err => reject(new ErrorWrapper(err)))
     })
   }
 }

--- a/src/services/test.service.js
+++ b/src/services/test.service.js
@@ -18,6 +18,8 @@ class TestService {
   * ->components/Test/TournaWholeList.vue
   * ->components/Test/TournaRow.vue
   * ->components/Test/TournaComment.vue
+  * from vuex
+  * ->store/modules/test.js
   */
 
   /*

--- a/src/store/modules/test.js
+++ b/src/store/modules/test.js
@@ -84,13 +84,12 @@ export default {
         .catch(err => commit('SET_ERROR', err.message))
     },
 
-    putComment ({commit}, payload) {
+    putComment ({commit}, payload, retry = 0) {
       console.log(payload)
       // WARNING : Payload is edited by following code
       let tempData = {
         ...payload,
-        id: uuidv4(),
-        time: moment().unix() }
+        id: uuidv4() }
       const {tempId} = tempData
       commit('ADD_COMMENT_SINGLE', tempData)
 
@@ -99,16 +98,27 @@ export default {
           if (res) {
             // 기회형님께: 아래의 두 줄을 제거하면
             // 댓글이 제대로 달리지 않았을 때 보이는
-            // 전송실패 뱃지가 딜립니다.
-            // remove the two lines of code below to see errors
+            // 전송실패 뱃지가 딜립니다.(코드리뷰에 참고)
+            // remove the two lines of code below to see timeout errors
             commit('TEMP_COMMENT_REMOVAL', tempId)
             this.getComments({commit})
           } else {
-            throw 'server did not respond for commenting'
+            throw new Error('코멘트 중 서버가 응답하지 않습니다')
           }
         })
-        .catch(err => commit('SET_ERROR', err.message))
-
+        .catch(err => {
+          commit('SET_ERROR', err.message)
+          // 실패에 대한 재시도는 단순히 재귀처리하였습니다.
+          const timespanRetry = 1500 // 서버 과부하를 막기 위하여 시간차를 줍니다.
+          const maxRetry = 5 // 재시도는 최대 5번만 시도됩니다. 이후에는 영구 오류처리합니다.
+          const _this = this
+          if (retry < maxRetry) {
+            setTimeout(function () {
+              console.log(`commenting failed...retrying comments ${retry} out of ${maxRetry}`)
+              _this.putComment({commit}, payload, retry++)
+            }, timespanRetry)
+          }
+        })
     }
   }
 }

--- a/src/store/modules/test.js
+++ b/src/store/modules/test.js
@@ -6,6 +6,7 @@ export default {
     loading: false,
     error: false,
     posts: [],
+    comments: [],
     pagination: {
       limit: 10,
       page: 0,
@@ -26,6 +27,9 @@ export default {
       console.log('mut data', data)
       state.posts = data
     },
+    SET_COMMENT (state,data) {
+      state.comments = data
+    },
     SET_PAGINATION (state, payload) {
       state.pagination = {
         page: payload.page || state.pagination.page,
@@ -43,7 +47,7 @@ export default {
   actions: {
     getPosts ({state, commit}, payload) {
       commit('SET_LOADING', true)
-      return TestService.getPosts()
+      return TestService.getPosts() //<-API에서 값을 불러오는 부분
         .then(response => {
           console.log(response)
           commit('SET_POST', response.data)
@@ -54,6 +58,24 @@ export default {
     setSearchOptions ({state, commit}, payload) {
       console.log(payload)
       // commit('SET_SEARCH_USER_ID', payload)
+    },
+
+    getComments({commit}){
+      return TestService.getComments()
+        .then(res=>{
+          commit('SET_COMMENT',res.data)
+        })
+        .catch(err=>commit('SET_ERROR',err.message))
+    },
+    putComment({userId,commentBody,postId}){
+      return TestService.putComment({userId,commentBody,postId})
+        .then(res=>{
+          if(res)
+            this.getComments()
+          else
+            throw "error with comment"
+        })
+        .catch(err=>commit('SET_ERROR',err.message))
     }
   }
 }

--- a/src/store/modules/test.js
+++ b/src/store/modules/test.js
@@ -67,7 +67,8 @@ export default {
         })
         .catch(err=>commit('SET_ERROR',err.message))
     },
-    putComment({userId,commentBody,postId}){
+    putComment({commit},payload){
+      let {userId,commentBody,postId} = payload
       return TestService.putComment({userId,commentBody,postId})
         .then(res=>{
           if(res)

--- a/src/store/modules/test.js
+++ b/src/store/modules/test.js
@@ -60,23 +60,25 @@ export default {
       // commit('SET_SEARCH_USER_ID', payload)
     },
 
-    getComments({commit}){
+    getComments ({commit}) {
       return TestService.getComments()
-        .then(res=>{
-          commit('SET_COMMENT',res.data)
+        .then(res => {
+          commit('SET_COMMENT', res.data)
         })
-        .catch(err=>commit('SET_ERROR',err.message))
+        .catch(err => commit('SET_ERROR', err.message))
     },
-    putComment({commit},payload){
-      let {userId,commentBody,postId} = payload
-      return TestService.putComment({userId,commentBody,postId})
-        .then(res=>{
-          if(res)
+
+    putComment ({commit}, payload) {
+      let {userId, commentBody, postId} = payload
+      return TestService.putComment({userId, commentBody, postId})
+        .then(res => {
+          if (res) {
             this.getComments()
-          else
-            throw "error with comment"
+          } else {
+            throw 'server did not respond for commenting'
+          }
         })
-        .catch(err=>commit('SET_ERROR',err.message))
+        .catch(err => commit('SET_ERROR', err.message))
     }
   }
 }

--- a/src/views/MyPage.vue
+++ b/src/views/MyPage.vue
@@ -7,7 +7,7 @@
       </div>
       <div>
         <label>Access Log:</label>
-        <div v-for="log in accessLog">{{log.userId}}, {{log.createdAt}}</div>
+        <div v-for="(log,idx) in accessLog" :key="idx">{{log.userId}}, {{log.createdAt}}</div>
       </div>
     </div>
 </template>

--- a/src/views/TestPage.vue
+++ b/src/views/TestPage.vue
@@ -27,6 +27,7 @@ export default {
   methods: {
     fetchData () {
       this.$store.dispatch('test/getPosts')
+      this.$store.dispatch('test/getComments')
     }
   },
   // 컴포넌트 라이프사이클 메서드 그룹
@@ -49,35 +50,37 @@ export default {
 }
 </script>
 <style lang="scss">
+%lines-shared {
+  border:solid;
+  border-width:7px;
+}
 .l1  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #464242;
-  border-width: 7px;
 }
 .l2  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #797474;
-  border-width: 7px;
 }
 .l3  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #a9a3a3;
-  border-width: 7px;
 }
 .l4  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #d4cfcf;
-  border-width: 7px;
 }
 .l5  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #e0e2e4;
-  border-width: 7px;
+}
+.l6 {
+  @extend %lines-shared;
+  border-color:#f3f3f3;
 }
 
 .lp  {
-  border: solid;
+  @extend %lines-shared;
   border-color: red;
-  border-width: 7px;
 }
 </style>

--- a/src/views/Tournaments.vue
+++ b/src/views/Tournaments.vue
@@ -43,35 +43,37 @@ export default {
 }
 </script>
 <style lang="scss">
+%lines-shared {
+  border:solid;
+  border-width:7px;
+}
 .l1  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #464242;
-  border-width: 7px;
 }
 .l2  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #797474;
-  border-width: 7px;
 }
 .l3  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #a9a3a3;
-  border-width: 7px;
 }
 .l4  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #d4cfcf;
-  border-width: 7px;
 }
 .l5  {
-  border: solid;
+  @extend %lines-shared;
   border-color: #e0e2e4;
-  border-width: 7px;
+}
+.l6 {
+  @extend %lines-shared;
+  border-color:#f3f3f3;
 }
 
 .lp  {
-  border: solid;
+  @extend %lines-shared;
   border-color: red;
-  border-width: 7px;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5898,6 +5898,10 @@ mocha-nightwatch@3.2.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8614,6 +8618,10 @@ utils-merge@1.0.1:
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
요청하신대로 코멘트 실패시 타임아웃처리를 추가하였습니다.
이제부터 코멘트를 달 때에는 임시로 uuid-v4 기준의 임시 아이디가 코멘트 object의 property로써 발급됩니다.
댓글이 성공적으로 달릴 경우에는 이 임시 아이디가 영구 삭제되고 아무런 흔적이 남지 않습니다.

_반면 실패시에는,_
사용자 화면에서는 댓글이 표시되지만 약 2.0초 후에도 임시 아이디가 남아있으면 컴포넌트는 서버에서 응답하지 않은 것으로 간주, 실패 아이콘이 달립니다. 한편 vuex 내부에서는 약 1.5초 간격을 두고 5번 재시도가 시도됩니다. 이후에도 응답이 없으면 실패 뱃지는 영구히 남게됩니다.

실패 화면을 보기 위해서는,
vuex(store/modules/test.js)에서 제가 별도로 코멘트를 달아놓은 부분의 두 줄을 제거하면 전송실패의 결과를 보실 수 있습니다.

각각의 실패는 고유한 시도로 남게 되어야 하므로, unique한 id를 생성하는 uuid 모듈이 package에 추가되었습니다. merge시 유의해야할 부분입니다.

**추가된 모듈:**

- uuid(uuid-v4) : https://www.npmjs.com/package/uuid