### PR TITLE
post feature added with spinner & markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "markdown-it": "^8.4.1",
     "register-service-worker": "^1.0.0",
+    "uuid": "^3.3.2",
     "vue": "^2.5.16",
     "vue-router": "^3.0.1",
     "vue-tabs-component": "^1.4.0",

--- a/src/components/Test/TournaWholeList.vue
+++ b/src/components/Test/TournaWholeList.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="l2">
-    TournaWholeList
+    <h2>TournaWholeList</h2>
+    <router-link to="/write">
+      <svg height="16px" id="Layer_1" style="enable-background:new 0 0 16 16;" version="1.1" viewBox="0 0 16 16" width="16px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M2.453,9.297C1.754,9.996,1,13.703,1,14c0,0.521,0.406,1,1,1c0.297,0,4.004-0.754,4.703-1.453l5.722-5.722l-4.25-4.25  L2.453,9.297z M12,1c-0.602,0-1.449,0.199-2.141,0.891L9.575,2.175l4.25,4.25l0.284-0.284C14.746,5.504,15,4.695,15,4  C15,2.343,13.656,1,12,1z"/></svg>
+      Write a new post
+    </router-link>
+    
     <div class="item" v-for="post in filteredPosts" :key="post.id">
       <TournaRow v-bind="post" />
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,11 @@ import App from './App.vue'
 import router from './router'
 import store from './store'
 import './registerServiceWorker'
+import SpinnerWave from './components/SpinnerWave.vue'
 
 Vue.config.productionTip = false
+
+Vue.component('spinner', SpinnerWave)
 
 new Vue({
   router,

--- a/src/router.js
+++ b/src/router.js
@@ -28,6 +28,7 @@ import TeamDFeed from './components/TeamDetail/TeamDFeed.vue'
 import TeamDMember from './components/TeamDetail/TeamDMember.vue'
 import TeamDSchedule from './components/TeamDetail/TeamDSchedule.vue'
 import TeamDRecord from './components/TeamDetail/TeamDRecord.vue'
+import Write from './views/Write.vue'
 import store from './store'
 
 Vue.use(Router)
@@ -69,6 +70,11 @@ export default new Router({
       path: '/test',
       name: 'test',
       component: TestPage
+    },
+    {
+      path: '/write',
+      name: 'write',
+      component: Write
     },
     {
       path: '/tournaments',

--- a/src/services/test.service.js
+++ b/src/services/test.service.js
@@ -12,6 +12,17 @@ class TestService {
         }).catch(error => reject(new ErrorWrapper(error)))
     })
   }
+  putPost (payload) {
+    return new Promise((resolve, reject) => {
+      axios.post('https://jsonplaceholder.typicode.com/posts')
+        .then(res => {
+          console.log('service putPost', res.data)
+          // 회경형님께 : 글 작성시 에러가 발생하는 것을 보려면 아래를 주석처리 해제해주세요
+          // throw new Error('error!!!')
+          return resolve(new ResponseWrapper(res, res.data))
+        }).catch(err => reject(new ErrorWrapper(err)))
+    })
+  }
 }
 
 export default new TestService()

--- a/src/store/modules/test.js
+++ b/src/store/modules/test.js
@@ -38,6 +38,18 @@ export default {
     },
     SET_LOADING (state, data) {
       state.loading = data
+    },
+    ADD_POST_SINGLE (state, data) {
+      console.log('posting an article...', data)
+      state.posts.push(data)
+    },
+    TEMP_POST_REMOVAL (state, data) {
+      state.posts.map(el => {
+        if (el.temp && el.tempId === data) {
+          el.temp = false
+        }
+        return el
+      })
     }
   },
   actions: {
@@ -54,6 +66,24 @@ export default {
     setSearchOptions ({state, commit}, payload) {
       console.log(payload)
       // commit('SET_SEARCH_USER_ID', payload)
+    },
+    putPost ({commit}, payload) {
+      return new Promise((resolve, reject) => {
+        let modifiedPayload = {...payload, id: Math.floor(Math.random() * 65525)}
+        commit('ADD_POST_SINGLE', modifiedPayload)
+        const {tempId} = payload
+        TestService.putPost(modifiedPayload)
+          .then(res => {
+            // after successful upload, delete the temp tag
+            commit('TEMP_POST_REMOVAL', tempId)
+            // then return success
+            resolve(tempId)
+          })
+          .catch(err => {
+            commit('SET_ERROR', err.message)
+            reject(new Error('글 포스팅 중 에러가 발생하였습니다'))
+          })
+      })
     }
   }
 }

--- a/src/views/Write.vue
+++ b/src/views/Write.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <h2>글 남기기</h2>
+    <form>
+      <spinner v-if="isLoading"></spinner>
+      <input type="text" v-model="title" placeholder="제목을 입력하세요" id="title"/>
+      <textarea v-model="source" placeholder="본문을 입력하세요"></textarea><br/>
+      <input type="submit" value="write" @click="putPost" />
+      <h3>본문 미리보기</h3>
+      <div id="preview">
+        <div v-html="parsed"></div>
+      </div>
+      <p>supports markdown standard(github style) : <a href="http://commonmark.org">http://commonmark.org/</a></p>
+    </form>
+  </div>
+</template>
+<script>
+import uuidv4 from 'uuid/v4'
+const marked = require('markdown-it')()
+export default{
+  data(){
+    return {
+      title:'',
+      source:'',
+      parsed:'',
+      isLoading: false
+    }
+  },
+  methods:{
+    putPost(e){
+      e.preventDefault()
+      const tempId = uuidv4()
+      let payload = {
+        tempId,
+        temp: true,
+        userId: 1234, //userId always has to be numbers, not string
+        title: this.title,
+        body: this.source
+      }
+      this.isLoading = true //attach spinner to this property
+      this.$store.dispatch('test/putPost', payload)
+      .then(res => {
+        console.log('posting success')
+        this.isLoading = false
+        this.$router.replace('/test') //use replace instead of go for rerouting vue-router element
+      }).catch(err => {
+        console.log('failed...retry', err)
+        this.putPost(e) //retrying....
+      })
+    }
+  },
+  watch:{
+    source:{
+      handler(){ 
+        this.parsed = marked.render(this.source)
+      }
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+  textarea{
+    width:90%;
+    height:300px;
+    max-width:90%;
+    min-height:100px;
+    resize:vertical;
+  }
+  input[type=submit]{
+    border:none;
+    padding:10px 30px 10px 30px;
+    background-color:darkslategray;
+    color:white;
+    transition:0.5s;
+    &:hover{
+      transition:0.5s;
+      color:darkslategray;
+      background-color:rgba(0,0,0,0.1)
+    }
+  }
+  #title{
+    width:90%;
+    margin-bottom:20px;
+    padding:10px 0 10px 0;
+  }
+  #preview{
+    display:flex;
+    justify-content:center;
+    > div{
+      min-height:100px;
+      width:90%;
+      text-align:left;
+      border:solid 1px rgba(0,0,0,0.3);
+    }
+  }
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5313,6 +5313,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -5647,6 +5653,16 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.1.tgz#206fe59b0e4e1b78a7c73250af9b34a4ad0aaf44"
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -5661,6 +5677,10 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -8423,6 +8443,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
+
 uglify-es@^3.3.4:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
@@ -8614,6 +8638,10 @@ utils-merge@1.0.1:
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
요청하신 포스팅 기능을 추가하였습니다.
특징은 아래와 같습니다.

- test페이지의 post를 row로 표현하는 부분 제일 위쪽에 글 작성 페이지로 이동되는 링크가 생겼습니다.
- MIT license의 markdown-it 마크다운 파서를 이용하여 마크다운을 사용하고 미리보기가 가능합니다.
- 이미 작성해두신 부분에 포함되어있는 SpinnerWave.vue 스피너를 활용했습니다.
- 글을 비동기적으로 포스팅 시도하며 실패할 경우 자동적으로 재시도하면서 계속 스피너를 보여줍니다.(services/test.service.js 에 주석처리 해놓은 에러를 푸시면 됩니다)

미구현된 부분
- 에러 타임아웃, 재시도 횟수는 따로 들어가지 않았습니다.
- 전체 화면을 블러처리하거나 어둡게 처리하는 부분을 CSS로 구현할 수 있으나 아직 구현해놓지 않았습니다. 나중에 merge시 충돌을 피하기 위하여 최대한 기존 리소스를 활용했으며, 별도의 feature branch로 구현해놓겠습니다.
- 본문 컴포넌트에서 아직 post 본문을 보는 기능이 없으므로 마크다운은 작성시 미리보기에서만 보실 수 있습니다.